### PR TITLE
Django 1.9 : The django.forms.util module has been renamed.

### DIFF
--- a/plupload/forms.py
+++ b/plupload/forms.py
@@ -5,7 +5,7 @@ from django.utils.encoding import force_unicode
 from django.utils.safestring import mark_safe
 from django.forms import Form
 from django.forms.fields import FilePathField
-from django.forms.util import flatatt
+from django.forms.utils import flatatt
 from django.forms.widgets import Input
 from django.template.loader import render_to_string
 from django.template.defaultfilters import capfirst


### PR DESCRIPTION
plupload/forms.py:8: RemovedInDjango19Warning: The django.forms.util module has been renamed. Use django.forms.utils instead.